### PR TITLE
fix a value conversion bug

### DIFF
--- a/common/install.sh
+++ b/common/install.sh
@@ -76,7 +76,7 @@ convert_legacy() {
           esac
           case "$LINE" in
             fidelity_bass_mode|fidelity_clarity_mode|ddc_device|*fireq|*convolver_kernel|dynamicsystem_device)
-              VALUE="$(basename "$VALUE")"
+              VALUE="$(basename -- "$VALUE")"
               [ "$LINE" == "ddc_device" -o "$LINE" == "convolver_kernel" ] && [ "$VALUE" ] && [ $VALUE -eq $VALUE ] 2>/dev/null && VALUE="$(grep "$VALUE" $MODPATH/common/VDCIndex.txt | sed -r "s/^[0-9]*=\"(.*)\"/\1/").vdc"
               LINE="$(eval echo \$$LINE)"
               sed -i "/$LINE/ s|>.*</string>|>$VALUE</string>|" "$DEST";;


### PR DESCRIPTION
This change make `convert` can handle negative value. for example: `viper4android.headphonefx.fireq.custom=string=-3.0;-3.0;-2.5;-2.5;-1.5;-1.0;-0.5;3.2;1.5;-2.0;` .